### PR TITLE
Fixes both locations sponsorship not counting properly

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,8 +150,8 @@ def check_contests():
                     pass
                 else:
                     eligibility = 1
-                
-                if c['sponsor_dependant'] == True and c['both_locations'] == True and e['sponsor1'] == (c['sponsor_number'] or c['sponsor_number2']) and e['sponsor2'] == (c['sponsor_number'] or c['sponsor_number2']):
+               
+                if c['sponsor_dependant'] == True and c['both_locations'] == True and ((e['sponsor1'] == c['sponsor_number']) or (e['sponsor1'] == c['sponsor_number2'])) and ((e['sponsor2'] == c['sponsor_number']) or (e['sponsor2'] == c['sponsor_number2'])):
                     pass
                 elif c['sponsor_dependant'] == True and c['primary_location'] == True and e['sponsor1'] == (c['sponsor_number'] or c['sponsor_number2']):
                     pass


### PR DESCRIPTION
Found the issue that made my Extreme Simracing entries not count properly when both sponsors in the entry were 216. The sponsorship check was comparing values that weren't boolean. Works for me after the fix with all combinations of sponsor options for that contest.
