### PR TITLE
Fix not grabbing more than 44 sessions

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,9 +153,9 @@ def check_contests():
                
                 if c['sponsor_dependant'] == True and c['both_locations'] == True and ((e['sponsor1'] == c['sponsor_number']) or (e['sponsor1'] == c['sponsor_number2'])) and ((e['sponsor2'] == c['sponsor_number']) or (e['sponsor2'] == c['sponsor_number2'])):
                     pass
-                elif c['sponsor_dependant'] == True and c['primary_location'] == True and e['sponsor1'] == (c['sponsor_number'] or c['sponsor_number2']):
+                elif c['sponsor_dependant'] == True and c['primary_location'] == True and (e['sponsor1'] == c['sponsor_number'] or e['sponsor1'] == c['sponsor_number2']):
                     pass
-                elif c['sponsor_dependant'] == True and c['secondary_location'] == True and e['sponsor2'] == (c['sponsor_number'] or c['sponsor_number2']):
+                elif c['sponsor_dependant'] == True and c['secondary_location'] == True and (e['sponsor2'] == c['sponsor_number'] or e['sponsor2'] == c['sponsor_number2']):
                     pass
                 elif c['sponsor_dependant'] == False:
                     pass

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def grab():
     url = "".join([url, file])
     r = s.get(url).json()
     try:
-        for n in range(len(r[0])): # Fix this bullshit, it's broken
+        for n in range(len(r)): # Fix this bullshit, it's broken
             sublist.append(r[n]['subsession_id'])
     except:
         pass


### PR DESCRIPTION
After running more than 44 sessions this season, it was aparent that it was not counting sessions past a certain number. The code was iterating over the length of items in the first session's info, not the amount of sessions. 

Maybe the comment - # Fix this bullshit, it's broken - is not needed anymore? :) 